### PR TITLE
Fix output capture for notification message

### DIFF
--- a/lib/go-rename-view.coffee
+++ b/lib/go-rename-view.coffee
@@ -52,11 +52,14 @@ class GoRenameView extends View
     if text.length > 0
       command = atom.config.get 'go-rename.path'
       args = ['-offset', "#{@filePath}:##{@byteOffset}", '-to', text]
-      stderr = (output)=>
-        @result = output
-      exit = (code)=>
+
+      result = []
+      stdout = (output) =>
+        result.push(output)
+
+      exit = (code) =>
         if code == 0
-          atom.notifications.addSuccess @result
+          atom.notifications.addSuccess result.join('')
         else
-          atom.notifications.addError @result
-      process = new BufferedProcess({command, args, stderr, exit})
+          atom.notifications.addError result.join('')
+      process = new BufferedProcess({command, args, stdout, stderr: stdout, exit})


### PR DESCRIPTION
The go-rename tool currently outputs the success message on stdout, but the
code was only capturing stderr for the notification message. Since stderr was
empty, Atom reported an error since it doesn't allow empty notification
messages.

This patch captures both stdout and stderr into a list that is then displayed
as the notification message.

Fixes issue #9